### PR TITLE
Fix CLI doc comment

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Name of the asses to show
+    /// Name of the asset to show
     #[arg(short, long)]
     name: String,
 }


### PR DESCRIPTION
## Summary
- fix `asset` typo in doc comment

## Testing
- `cargo test`
- `cargo fmt` *(fails: rustfmt missing)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fa48119fc83309f7b4fa33bb8ee88