### PR TITLE
Add core crate README

### DIFF
--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,18 @@
+# stowr-core
+
+`stowr-core` provides the shared domain logic and data structures for all stowr frontends. It is intended to be a small, well-tested library that each user interface can build upon.
+
+## Purpose
+
+- Define the core data model for assets and collections
+- Expose reusable utilities and abstractions that are UI agnostic
+- Offer a simple storage layer (planned: embedded SurrealDB) so all frontends can operate on the same data
+
+## Planned Features
+
+- Centralized types for items, tags and storage locations
+- Import/export helpers for various file formats
+- Async task runner for background operations
+- Optional local database powered by SurrealDB
+
+This crate is still in its early stages; contributions and ideas are welcome!


### PR DESCRIPTION
## Summary
- document stowr-core purpose and planned features
- restore CLI README link in root README

## Testing
- `cargo fmt -- --check` *(failed: rustfmt missing)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_683fa89d97208330a078a1aa9205cbb0